### PR TITLE
Fix cmp op.

### DIFF
--- a/app/extensions/poly1305/poly1305_avx-32.inc
+++ b/app/extensions/poly1305/poly1305_avx-32.inc
@@ -7,7 +7,7 @@ FN_END poly1305_block_size_avx
 
 
 GLOBAL_HIDDEN_FN poly1305_auth_avx
-cmp $64, 12(%esp)
+cmpl $64, 12(%esp)
 jbe poly1305_auth_x86_local
 pushl %ebp
 movl %esp, %ebp

--- a/app/extensions/poly1305/poly1305_avx2-32.inc
+++ b/app/extensions/poly1305/poly1305_avx2-32.inc
@@ -8,7 +8,7 @@ FN_END poly1305_block_size_avx2
 
 
 GLOBAL_HIDDEN_FN poly1305_auth_avx2
-cmp $64, 12(%esp)
+cmpl $64, 12(%esp)
 jbe poly1305_auth_x86_local
 pushl %ebp
 movl %esp, %ebp

--- a/app/extensions/poly1305/poly1305_sse2-32.inc
+++ b/app/extensions/poly1305/poly1305_sse2-32.inc
@@ -6,7 +6,7 @@ ret
 FN_END poly1305_block_size_sse2
 
 GLOBAL_HIDDEN_FN poly1305_auth_sse2
-cmp $64, 12(%esp)
+cmpl $64, 12(%esp)
 jb poly1305_auth_x86_local
 pushl %ebp
 movl %esp, %ebp


### PR DESCRIPTION
This fixes build of poly1305 on i386 boxes with FreeBSD. Otherwise, I got the following error:

```
cc -m32 -c -I./app/extensions -I./app/include -I./framework/include -I./framework/driver -I./framework/driver/x86 -Wa,-I./app/extensions -Wa,-I./app/include -Wa,-I./framework/include -Wa,-I./framework/driver -Wa,-I./framework/driver/x86 -MMD -MF build/app/extensions/poly1305/poly1305.temp -D BUILDING_ASM -c -o build/app/extensions/poly1305/poly1305.o app/extensions/poly1305/poly1305.S
Included from <instantiation>:2:
./app/extensions/poly1305/poly1305_avx2-32.inc:11:1: error: ambiguous instructions require an explicit suffix (could be 'cmpb', 'cmpw', 'cmpl', or 'cmpq')
cmp $64, 12(%esp)
^
<instantiation>:2:2: note: while in macro instantiation
 INCLUDE_IF_X86_32BIT "poly1305/poly1305_avx2-32.inc"
 ^
app/extensions/poly1305/poly1305.S:14:1: note: while in macro instantiation
INCLUDE_IF_AVX2_32BIT "poly1305/poly1305_avx2-32.inc"
^
Included from <instantiation>:2:
./app/extensions/poly1305/poly1305_avx-32.inc:10:1: error: ambiguous instructions require an explicit suffix (could be 'cmpb', 'cmpw', 'cmpl', or 'cmpq')
cmp $64, 12(%esp)
^
<instantiation>:2:2: note: while in macro instantiation
 INCLUDE_IF_X86_32BIT "poly1305/poly1305_avx-32.inc"
 ^
app/extensions/poly1305/poly1305.S:15:1: note: while in macro instantiation
INCLUDE_IF_AVX_32BIT "poly1305/poly1305_avx-32.inc"
^
```
